### PR TITLE
Alpine image on linux/amd64 for v0.1.7

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,26 @@
+FROM --platform=${TARGETPLATFORM:-linux/amd64} rust:1.68-alpine as builder
+
+RUN apk add musl-dev
+
+RUN rustup target add x86_64-unknown-linux-musl
+
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+
+WORKDIR /usr/src/html2adf
+
+COPY Cargo.* ./
+COPY src ./src
+
+RUN cargo test
+RUN cargo build --frozen --target x86_64-unknown-linux-musl --release
+
+
+
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine
+
+RUN apk add libgcc
+
+COPY --from=builder /usr/src/html2adf/target/x86_64-unknown-linux-musl/release/html2adf /usr/local/bin/html2adf
+
+ENTRYPOINT ["html2adf"]
+CMD []

--- a/REAMDE-alpine.md
+++ b/REAMDE-alpine.md
@@ -1,0 +1,8 @@
+Docker images on `linux/amd64` with `alpine` for [wouterken/html2adf](https://github.com/wouterken/htmltoadf), instead of `linux/arm64` with `debian:buster-slim`.
+
+**Usage**
+
+```bash
+$ echo "<h1>Hello world<p>Test</p></h1>" | docker run --rm -i aneroid/html2adf:0.1.7-alpine
+{"version":1,"type":"doc","content":[{"type":"heading","attrs":{"level":1},"content":[{"type":"text","text":"Hello world"},{"type":"text","text":"Test"}]}]}
+```


### PR DESCRIPTION
Dockerfile for `alpine` images on `linux/amd64`, instead of `debian:buster-slim` images on `linux/arm64`.